### PR TITLE
Update to add a default language tag

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseURL = "https://www.o3de.org"
 title = "Open 3D Engine"
 disableKinds = ["taxonomy", "taxonomyTerm"]
 copyright = "O3DE Open 3D Engine Contributors | Documentation Distributed under CC-BY 4.0"
+languageCode = "en-us"
 
 [module]
   [module.hugoVersion]


### PR DESCRIPTION
Fixing this bug: https://github.com/o3de/o3de.org/issues/2345 Added the line languageCode = "en-us"

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary
This is a minor change to add a default language to each of the webpages. This helps search engines and assistive technology. 


### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

